### PR TITLE
Fix ID-generation vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const express = require("express");
 const PORT = process.env.PORT || 40404;
 const cors = require("cors");
@@ -29,9 +30,7 @@ app.post("/secret", (req, res) => {
   //generate unique id
   let id;
   do {
-    id = Math.random()
-      .toString(36)
-      .substring(7);
+    id = generateId()
   } while (secrets[id]);
 
   let timeout = 0;
@@ -52,6 +51,12 @@ app.post("/secret", (req, res) => {
     })
   );
 });
+
+// Generate a cryptographically-secure random ID in 'URL and filename safe' Base 64
+// https://tools.ietf.org/html/rfc4648#section-5
+function generateId() {
+    return crypto.randomBytes(6).toString('base64').replace(/\+/g, '-').replace(/\//g, '_')
+}
 
 app.listen(PORT, () => {
   console.log(`listening on port ${PORT}`);


### PR DESCRIPTION
`Math.random()` is not crypographically secure, so will generate IDs that may be guessed. We replace it with the secure `crypto.randomBytes()` function, base64-encoding the resulting buffer.

Also, we use `crypto.randomBytes(6)`, producing 6 bytes, which after base64-encoding gives us a 8 characters and so a range of 64^8 not 36^7 different ID variations. This presents a reduced risk of ID generation collisions.